### PR TITLE
map .jpeg to image/image mime type

### DIFF
--- a/src/ContentModifier/ReplaceImagesWithBase64VersionsModifier.php
+++ b/src/ContentModifier/ReplaceImagesWithBase64VersionsModifier.php
@@ -11,7 +11,7 @@ use Symfony\Component\DomCrawler\Crawler;
 class ReplaceImagesWithBase64VersionsModifier implements PageContentModifier
 {
     private const FILE_TYPES = [
-        '/\\.jpg$/' => 'image/jpeg',
+        '/\\.jpe?g$/' => 'image/jpeg',
         '/\\.png$/' => 'image/png',
         '/\\.gif/' => 'image/gif',
     ];


### PR DESCRIPTION
Avoids this error:

```
In ReplaceImagesWithBase64VersionsModifier.php line 36:

  Could not determine mime type for https://basecamp.com/assets/images/books/shapeup/cover_summary.jpeg


```