### PR TITLE
Fix mime type detection failing when image URLs contain query strings

### DIFF
--- a/src/ContentModifier/ReplaceImagesWithBase64VersionsModifier.php
+++ b/src/ContentModifier/ReplaceImagesWithBase64VersionsModifier.php
@@ -75,9 +75,10 @@ class ReplaceImagesWithBase64VersionsModifier implements PageContentModifier
      */
     private function getMimeType(string $imageUri): string
     {
+        $path = parse_url($imageUri, PHP_URL_PATH) ?? $imageUri; 
         foreach (self::FILE_TYPES as $regex => $mime) {
             try {
-                if (preg_match($regex, $imageUri)) {
+                if (preg_match($regex, $path)) {
                     return $mime;
                 }
             } catch (PcreException $e) {


### PR DESCRIPTION
The regex patterns in getMimeType() use a `$` anchor which fails to match 
when image URLs contain query strings or fragments after the file extension.

Fix by running the match against only the URL path component (via parse_url) 
rather than the full URI.